### PR TITLE
DISCARD: wip #2: improve Python server

### DIFF
--- a/messenger_grpc/server.py
+++ b/messenger_grpc/server.py
@@ -1,4 +1,4 @@
-from time import sleep
+from asyncio import sleep
 
 from . import chat_service_pb2 as cs_structs
 from . import chat_service_pb2_grpc as cs_services
@@ -7,22 +7,25 @@ from . import chat_service_pb2_grpc as cs_services
 class ChatServer(cs_services.ChatServiceServicer):
     def __init__(self):
         self.rooms = {}
-        self.clients = {}
+        self.clients = {}  # key: room id, val: set of clients in that room
 
-    def connect(self, request, context):
+    async def connect(self, request, context):
         """
         client connects to server
         """
         room = request.room
         user = request.user
+
         if room not in self.rooms:
             self.rooms[room] = []
         if room not in self.clients:
             self.clients[room] = set()
+
         self.clients[room].add(user)
+
         return cs_structs.ConnectResponse(message=f"{user} connected to room {room}")
 
-    def disconnect(self, request, context):
+    async def disconnect(self, request, context):
         """
         client disconnects from server
         """
@@ -32,7 +35,7 @@ class ChatServer(cs_services.ChatServiceServicer):
             self.clients[room].discard(user)
         return cs_structs.Empty()
 
-    def sendMessage(self, request, context):
+    async def sendMessage(self, request, context):
         """
         client sends a message to server
         """
@@ -42,7 +45,7 @@ class ChatServer(cs_services.ChatServiceServicer):
         self.rooms[room].append(request)
         return cs_structs.Empty()
 
-    def receiveMessages(self, request, context):
+    async def receiveMessages(self, request, context):
         """
         client receives messages from server
         """
@@ -51,9 +54,9 @@ class ChatServer(cs_services.ChatServiceServicer):
             self.rooms[room] = []
 
         last_index = 0
-        while True:
+        while not context.done():
             while len(self.rooms[room]) > last_index:
                 message = self.rooms[room][last_index]
                 last_index += 1
                 yield message
-            sleep(0.1)  # to prevent CPU overload
+            await sleep(0.01)

--- a/scripts/pyclient.py
+++ b/scripts/pyclient.py
@@ -36,6 +36,8 @@ class Client:
                 while True:
                     sleep(1)
             except KeyboardInterrupt:
+                pass
+            finally:
                 self.client.disconnect(stub, user, room)
                 print(f"{user} disconnected from room {room}")
 


### PR DESCRIPTION
The `pyserver.py` has been converted to `asyncio`, which makes it easy to fix the following problems:

- Shutdown gracefully on Ctrl-C (SIGTERM/SIGINT)
- Get rid of explicit `sleep(0.1)`